### PR TITLE
Aia 12004 tag 8.4.1: Performance improvements to angular-tree-component to work with large trees

### DIFF
--- a/lib/components/tree-node-checkbox.component.ts
+++ b/lib/components/tree-node-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation, OnInit, OnChanges } from '@angular/core';
 import { TreeNode } from '../models/tree-node.model';
 
 @Component({
@@ -11,11 +11,26 @@ import { TreeNode } from '../models/tree-node.model';
         class="tree-node-checkbox"
         type="checkbox"
         (click)="node.mouseAction('checkboxClick', $event)"
-        [checked]="node.isSelected"
-        [indeterminate]="node.isPartiallySelected"/>
+        [checked]="node.someChildrenSelected()"
+        [indeterminate]="node.someChildrenSelected() && !node.allChildrenSelected()"/>
     </ng-container>
   `
 })
-export class TreeNodeCheckboxComponent {
+export class TreeNodeCheckboxComponent implements OnInit, OnChanges {
   @Input() node: TreeNode;
+
+  public ngOnInit(): void {
+    /* Set on Query */
+    if (this.node.parent && this.node.options.lazySelect && this.node.parent.allChildrenSelected()) {
+        this.node.setIsSelected(this.node.parent.allChildrenSelected());
+    }
+  }
+
+  public ngOnChanges(changes): void {
+    const { node } = changes;
+    if (node) {
+      this.node = node.currentValue;
+    }
+  }
+
 }

--- a/lib/defs/api.ts
+++ b/lib/defs/api.ts
@@ -286,7 +286,7 @@ export interface ITreeOptions {
      */
     scrollContainer?: HTMLElement;
 
-    /* Should select even propogate to child nodes lazily*/
+    /* Select and deselect events propogates lazily to child and parent nodes in tree*/
     lazySelect?: boolean;
  }
 

--- a/lib/defs/api.ts
+++ b/lib/defs/api.ts
@@ -285,6 +285,9 @@ export interface ITreeOptions {
      * and then the scrolling container is the viewport inside the tree component
      */
     scrollContainer?: HTMLElement;
+
+    /* Should select even propogate to child nodes lazily*/
+    lazySelect?: boolean;
  }
 
 export interface ITreeNode {

--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -155,6 +155,6 @@ export class TreeOptions {
   }
 
   get lazySelect(): boolean {
-    return this.options?.lazySelect ? this.options?.lazySelect : false;
+    return this.options.lazySelect !== undefined ? this.options.lazySelect : false;
   }
 }

--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -153,4 +153,8 @@ export class TreeOptions {
   get dropSlotHeight(): number {
     return isNumber(this.options.dropSlotHeight) ? this.options.dropSlotHeight : 2;
   }
+
+  get lazySelect(): boolean {
+    return this.options?.lazySelect ? this.options?.lazySelect : false;
+  }
 }


### PR DESCRIPTION
PS: This PR is raised against the 8.4.1 release, which is release we use for `angular-tree-package`. The latest release has breaking changes for our components and requires more work to upgrade. 

Front end changes to work with this: https://github.com/mindbridge-ai/squanto-web-audit/pull/5685

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[] Bugfix
[v] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behaviour?
The current behaviour is to check the state of all nodes and their children to compute the internal state in case of tri-State option. 

## What is the new behavior?
Added cache on nodes to keep track of child select status and propagate state only if necessary to improve performance in case of huge trees. 

## Does this PR introduce a breaking change?
Yess. 
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
