### PR TITLE
Removing the component flags as state is not computing properly,

### DIFF
--- a/projects/angular-tree-component/src/lib/components/tree-node-checkbox.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree-node-checkbox.component.ts
@@ -17,8 +17,10 @@ import { TreeNode } from '../models/tree-node.model';
         class="tree-node-checkbox"
         type="checkbox"
         (click)="node.mouseAction('checkboxClick', $event)"
-        [checked]="checked"
-        [indeterminate]="indeterminate"
+        [checked]="node.someChildrenSelected()"
+        [indeterminate]="
+          node.someChildrenSelected() && !node.allChildrenSelected()
+        "
       />
     </ng-container>
   `
@@ -45,9 +47,6 @@ export class TreeNodeCheckboxComponent implements OnInit, OnChanges {
     const { node } = changes;
     if (node) {
       this.node = node.currentValue;
-      this.checked = node.someChildrenSelected();
-      this.indeterminate =
-        node.someChildrenSelected() && !node.allChildrenSelected();
     }
   }
 }


### PR DESCRIPTION
Removing the components flags as the state is not computing properly, as
ngOnChanges not getting called when the internal private state of the object is getting changed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
