### PR TITLE
AIA-14247: Send selection events for branch nodes

### DIFF
--- a/projects/angular-tree-component/src/lib/models/tree-node.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree-node.model.ts
@@ -378,16 +378,12 @@ export class TreeNode implements ITreeNode {
     // A selection event won't be sent (above) for non-leaf nodes. We need that (explicit user)
     // event to manage state properly in mb-tree.
     //
-    // At least for now, we're going to restrict this to the multi-select case in order to
-    // minimize potential side-effects.
-    //
-    if (this.options.useCheckbox && !this.isSelectable()) {
-      if (!currentStatus) {
-         this.fireEvent({ eventName: TREE_EVENTS.select, node: this, fromUserAction: true });
+    if (!this.isSelectable()) {
+      if (!currentStatus || !this.options.useCheckbox) {
+        this.fireEvent({ eventName: TREE_EVENTS.select, node: this, fromUserAction: true });
       } else {
         this.fireEvent({ eventName: TREE_EVENTS.deselect, node: this, fromUserAction: true });
-      }
-  
+      } 
     }
 
     if (this.parent) {


### PR DESCRIPTION
## PR Checklist
With node click now using select instead of activate, we need to send a selection event to branch nodes if we're not using multiselect (mb-tree triggered a selection based on ACTIVATE vs SELECT when not in multiselect mode)

- [ ] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
